### PR TITLE
Adds call to WifiP2pManager.removeGroup to disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This plugin is in alpha and only supports android at the moment.
 ## Getting Started
 
 ### Required permissions
+
 - `android.permission.CHANGE_WIFI_STATE`
 - `android.permission.ACCESS_FINE_LOCATION`
 - `android.permission.ACCESS_COARSE_LOCATION`
@@ -19,7 +20,9 @@ This plugin is in alpha and only supports android at the moment.
 - `android.permission.ACCESS_WIFI_STATE`
 
 ### Request permission
+
 In order to scan for devices and connect to devices you need to ask for the location Permission
+
 ```dart
 Future<bool> _checkPermission() async {
   if (!await FlutterP2p.isLocationPermissionGranted()) {
@@ -31,8 +34,10 @@ Future<bool> _checkPermission() async {
 ```
 
 ### Register / unregister from WiFi events
+
 To receive notifications for connection changes or device changes (peers discovered etc.) you have
 to subscribe to the wifiEvents and register the plugin to the native events.
+
 ```dart
 class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   @override
@@ -51,7 +56,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // Stop handling events when the app doesn't run to prevent battery draining
-    
+
     if (state == AppLifecycleState.resumed) {
       _register();
     } else if (state == AppLifecycleState.paused) {
@@ -66,7 +71,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       return;
     }
     _subscriptions.add(FlutterP2p.wifiEvents.stateChange.listen((change) {
-      // Handle wifi state change 
+      // Handle wifi state change
     }));
 
     _subscriptions.add(FlutterP2p.wifiEvents.connectionChange.listen((change) {
@@ -91,9 +96,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 }
 ```
 
-
 ### Discover devices
+
 After you subscribed to the events you only need to call the `FlutterP2p.discoverDevices()` method.
+
 ```dart
 
 List<WifiP2pDevice> _peers = [];
@@ -112,11 +118,12 @@ void _register() async {
 }
 
 void _discover() {
-  FlutterP2p.discoverDevices(); 
+  FlutterP2p.discoverDevices();
 }
 ```
 
 ### Connect to a device
+
 Call `FlutterP2p.connect(device);` and listen to the `FlutterP2p.wifiEvents.connectionChange`
 
 ```dart
@@ -140,10 +147,22 @@ Call `FlutterP2p.connect(device);` and listen to the `FlutterP2p.wifiEvents.conn
   }
 ```
 
+### Disconnect from current P2P group
+
+Call `FlutterP2p.removeGroup()`
+
+```dart
+ void _disconnect() async {
+   FlutterP2p.removeGroup();
+ }
+```
+
 ### Transferring data between devices
+
 After you are connected to a device you can transfer data async in both directions (client -> host, host -> client).
 
 On the host:
+
 ```dart
   // Open a port and create a socket
 
@@ -165,18 +184,19 @@ On the host:
       }
     });
 
-    // Write data to the client using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method 
+    // Write data to the client using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method
 
-    
+
     print("_openPort done");
 
     // accept a connection on the created socket
     await FlutterP2p.acceptPort(port);
     print("_accept done");
   }
-``` 
+```
 
 On the client:
+
 ```dart
   // Connect to the port and create a socket
 
@@ -202,9 +222,9 @@ On the client:
         buffer = "";
       }
     });
-    
-    // Write data to the host using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method 
+
+    // Write data to the host using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method
 
     print("_connectToPort done");
   }
-``` 
+```

--- a/android/src/main/kotlin/de/mintware/flutter_p2p/FlutterP2pPlugin.kt
+++ b/android/src/main/kotlin/de/mintware/flutter_p2p/FlutterP2pPlugin.kt
@@ -20,6 +20,7 @@ import android.content.ContentValues.TAG
 import android.content.Context
 import android.content.IntentFilter
 import android.net.wifi.p2p.WifiP2pManager
+import android.net.wifi.p2p.WifiP2pGroup
 import android.os.Looper
 import android.util.Log
 import java.lang.reflect.Method
@@ -230,6 +231,28 @@ class FlutterP2pPlugin(private val registrar: Registrar
 
             override fun onFailure(reasonCode: Int) {
                 result.error(reasonCode.toString(), null, null)
+            }
+        })
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun removeGroup(call: MethodCall, result: Result) {
+        manager.requestGroupInfo(channel, object : WifiP2pManager.GroupInfoListener {
+            override fun onGroupInfoAvailable(group: WifiP2pGroup) {
+                if (group != null) {
+                    manager.removeGroup(channel, object : WifiP2pManager.ActionListener {
+                        override fun onSuccess() {
+                            result.success(true)
+                        }
+            
+                        override fun onFailure(reasonCode: Int) {
+                            result.error(reasonCode.toString(), null, null)
+                        }
+                    })
+                } else {
+                    //signal success as the device is not currently a member of a group
+                    result.success(true)
+                }
             }
         })
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -183,6 +183,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                   : null,
               child: Text("Send hello world"),
             ),
+            RaisedButton(
+              onPressed: _isConnected ? () => FlutterP2p.removeGroup() : null,
+              child: Text("Disconnect"),
+            ),
             Expanded(
               child: ListView(
                 children: this.devices.map((d) {

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -65,6 +65,10 @@ class FlutterP2p {
     return await _channel.invokeMethod("cancelConnect", {});
   }
 
+  static Future<bool> removeGroup() async {
+    return await _channel.invokeMethod("removeGroup", {});
+  }
+
   //endregion
 
   //region Host Advertising


### PR DESCRIPTION
First off, thanks for this plugin. Its awesome!

This PR adds a call to `WifiP2pManager.removeGroup` to be able to disconnect from the currently connected P2P group. I am brand new to Flutter and also Kotlin so if anything is not looking right please let me know and I can fix. I updated the example app with a "Disconnect" button so you can try it out. 