### PR TITLE
Adds discovery change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This plugin is in alpha and only supports android at the moment.
 ## Getting Started
 
 ### Required permissions
+
 - `android.permission.CHANGE_WIFI_STATE`
 - `android.permission.ACCESS_FINE_LOCATION`
 - `android.permission.ACCESS_COARSE_LOCATION`
@@ -19,7 +20,9 @@ This plugin is in alpha and only supports android at the moment.
 - `android.permission.ACCESS_WIFI_STATE`
 
 ### Request permission
+
 In order to scan for devices and connect to devices you need to ask for the location Permission
+
 ```dart
 Future<bool> _checkPermission() async {
   if (!await FlutterP2p.isLocationPermissionGranted()) {
@@ -31,8 +34,10 @@ Future<bool> _checkPermission() async {
 ```
 
 ### Register / unregister from WiFi events
+
 To receive notifications for connection changes or device changes (peers discovered etc.) you have
 to subscribe to the wifiEvents and register the plugin to the native events.
+
 ```dart
 class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   @override
@@ -51,7 +56,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // Stop handling events when the app doesn't run to prevent battery draining
-    
+
     if (state == AppLifecycleState.resumed) {
       _register();
     } else if (state == AppLifecycleState.paused) {
@@ -66,7 +71,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       return;
     }
     _subscriptions.add(FlutterP2p.wifiEvents.stateChange.listen((change) {
-      // Handle wifi state change 
+      // Handle wifi state change
     }));
 
     _subscriptions.add(FlutterP2p.wifiEvents.connectionChange.listen((change) {
@@ -81,6 +86,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       // Handle discovered peers
     }));
 
+    _subscriptions.add(FlutterP2p.wifiEvents.discoveryChange.listen((change) {
+      // Handle discovery state changes
+    }));
+
     FlutterP2p.register();  // Register to the native events which are send to the streams above
   }
 
@@ -91,9 +100,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 }
 ```
 
-
 ### Discover devices
+
 After you subscribed to the events you only need to call the `FlutterP2p.discoverDevices()` method.
+
 ```dart
 
 List<WifiP2pDevice> _peers = [];
@@ -112,11 +122,12 @@ void _register() async {
 }
 
 void _discover() {
-  FlutterP2p.discoverDevices(); 
+  FlutterP2p.discoverDevices();
 }
 ```
 
 ### Connect to a device
+
 Call `FlutterP2p.connect(device);` and listen to the `FlutterP2p.wifiEvents.connectionChange`
 
 ```dart
@@ -141,9 +152,11 @@ Call `FlutterP2p.connect(device);` and listen to the `FlutterP2p.wifiEvents.conn
 ```
 
 ### Transferring data between devices
+
 After you are connected to a device you can transfer data async in both directions (client -> host, host -> client).
 
 On the host:
+
 ```dart
   // Open a port and create a socket
 
@@ -165,18 +178,19 @@ On the host:
       }
     });
 
-    // Write data to the client using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method 
+    // Write data to the client using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method
 
-    
+
     print("_openPort done");
 
     // accept a connection on the created socket
     await FlutterP2p.acceptPort(port);
     print("_accept done");
   }
-``` 
+```
 
 On the client:
+
 ```dart
   // Connect to the port and create a socket
 
@@ -202,9 +216,9 @@ On the client:
         buffer = "";
       }
     });
-    
-    // Write data to the host using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method 
+
+    // Write data to the host using the _socket.write(UInt8List) or `_socket.writeString("Hello")` method
 
     print("_connectToPort done");
   }
-``` 
+```

--- a/android/src/main/kotlin/de/mintware/flutter_p2p/FlutterP2pPlugin.kt
+++ b/android/src/main/kotlin/de/mintware/flutter_p2p/FlutterP2pPlugin.kt
@@ -48,6 +48,7 @@ class FlutterP2pPlugin(private val registrar: Registrar
         private const val CH_PEERS_CHANGE = "bc/peers-change"
         private const val CH_CON_CHANGE = "bc/connection-change"
         private const val CH_DEVICE_CHANGE = "bc/this-device-change"
+        private const val CH_DISCOVERY_CHANGE = "bc/discovery-change"
         private const val CH_SOCKET_READ = "socket/read"
         val config: Config = Config();
 
@@ -72,6 +73,7 @@ class FlutterP2pPlugin(private val registrar: Registrar
         eventPool.register(CH_CON_CHANGE)
         eventPool.register(CH_DEVICE_CHANGE)
         eventPool.register(CH_SOCKET_READ)
+        eventPool.register(CH_DISCOVERY_CHANGE)
 
         socketPool = SocketPool(eventPool.getHandler(CH_SOCKET_READ))
     }
@@ -86,6 +88,8 @@ class FlutterP2pPlugin(private val registrar: Registrar
             addAction(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION)
             // Indicates this device'base details have changed.
             addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION)
+            // Indicates the state of peer discovery has changed
+            addAction(WifiP2pManager.WIFI_P2P_DISCOVERY_CHANGED_ACTION)
         }
     }
 
@@ -135,7 +139,8 @@ class FlutterP2pPlugin(private val registrar: Registrar
                 eventPool.getHandler(CH_STATE_CHANGE).sink,
                 eventPool.getHandler(CH_PEERS_CHANGE).sink,
                 eventPool.getHandler(CH_CON_CHANGE).sink,
-                eventPool.getHandler(CH_DEVICE_CHANGE).sink
+                eventPool.getHandler(CH_DEVICE_CHANGE).sink,
+                eventPool.getHandler(CH_DISCOVERY_CHANGE).sink
         )
         registrar.context().registerReceiver(receiver, intentFilter)
         result.success(true)

--- a/android/src/main/kotlin/de/mintware/flutter_p2p/utility/ProtoHelper.kt
+++ b/android/src/main/kotlin/de/mintware/flutter_p2p/utility/ProtoHelper.kt
@@ -13,6 +13,7 @@ package de.mintware.flutter_p2p.utility
 import android.net.NetworkInfo
 import android.net.wifi.p2p.WifiP2pDevice
 import android.net.wifi.p2p.WifiP2pInfo
+import android.net.wifi.p2p.WifiP2pManager
 import com.google.protobuf.ByteString
 import de.mintware.flutter_p2p.Protos
 
@@ -22,6 +23,12 @@ class ProtoHelper {
             return Protos.StateChange.newBuilder()
                     .setIsEnabled(isEnabled)
                     .build()
+        }
+
+        fun create(discoveryState: Int) : Protos.DiscoveryStateChange {
+            return Protos.DiscoveryStateChange.newBuilder()
+                    .setIsDiscovering(discoveryState != WifiP2pManager.WIFI_P2P_DISCOVERY_STOPPED)
+                    .build();
         }
 
         fun create(device: WifiP2pDevice): Protos.WifiP2pDevice {

--- a/android/src/main/kotlin/de/mintware/flutter_p2p/wifi_direct/WiFiDirectBroadcastReceiver.kt
+++ b/android/src/main/kotlin/de/mintware/flutter_p2p/wifi_direct/WiFiDirectBroadcastReceiver.kt
@@ -26,7 +26,8 @@ class WiFiDirectBroadcastReceiver(private val manager: WifiP2pManager,
                                   private val stateChangedSink: EventChannel.EventSink?,
                                   peersChangedSink: EventChannel.EventSink?,
                                   private val connectionChangedSink: EventChannel.EventSink?,
-                                  private val thisDeviceChangedSink: EventChannel.EventSink?
+                                  private val thisDeviceChangedSink: EventChannel.EventSink?,
+                                  private val discoveryChangedSink: EventChannel.EventSink?
 ) : BroadcastReceiver() {
 
     private val peerListListener = WiFiDirectPeerListListener(peersChangedSink);
@@ -41,6 +42,7 @@ class WiFiDirectBroadcastReceiver(private val manager: WifiP2pManager,
             WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION -> onPeersChanged()
             WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION -> onConnectionChanged(intent)
             WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION -> onThisDeviceChanged(intent)
+            WifiP2pManager.WIFI_P2P_DISCOVERY_CHANGED_ACTION -> onDiscoveryChanged(intent)
         }
     }
 
@@ -91,5 +93,11 @@ class WiFiDirectBroadcastReceiver(private val manager: WifiP2pManager,
         val device = intent.getParcelableExtra(WifiP2pManager.EXTRA_WIFI_P2P_DEVICE) as WifiP2pDevice
         val dev: Protos.WifiP2pDevice = ProtoHelper.create(device);
         thisDeviceChangedSink?.success(dev.toByteArray())
+    }
+
+    private fun onDiscoveryChanged(intent: Intent) {
+        val discoveryState = intent.getIntExtra(WifiP2pManager.EXTRA_DISCOVERY_STATE, WifiP2pManager.WIFI_P2P_DISCOVERY_STOPPED);
+        val stateChange: Protos.DiscoveryStateChange = ProtoHelper.create(discoveryState);
+        discoveryChangedSink?.success(stateChange.toByteArray());
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,6 +76,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           "deviceChange: ${change.deviceName} / ${change.deviceAddress} / ${change.primaryDeviceType} / ${change.secondaryDeviceType} ${change.isGroupOwner ? 'GO' : '-GO'}");
     }));
 
+    _subscriptions.add(FlutterP2p.wifiEvents.discoveryChange.listen((change) {
+      print("discoveryStateChange: ${change.isDiscovering}");
+    }));
+
     _subscriptions.add(FlutterP2p.wifiEvents.peersChange.listen((change) {
       print("peersChange: ${change.devices.length}");
       change.devices.forEach((device) {

--- a/lib/broadcast_handler.dart
+++ b/lib/broadcast_handler.dart
@@ -25,10 +25,14 @@ class WiFiDirectBroadcastReceiver {
   static EventChannel _thisDeviceChangeChannel =
       EventChannel("$_channelBase/bc/this-device-change");
 
+  static EventChannel _discoveryChangeChannel =
+      EventChannel("$_channelBase/bc/discovery-change");
+
   static Stream<StateChange> _stateChangeStream;
   static Stream<WifiP2pDeviceList> _peersChangeStream;
   static Stream<ConnectionChange> _connectionChangeStream;
   static Stream<WifiP2pDevice> _thisDeviceChangeStream;
+  static Stream<DiscoveryStateChange> _discoveryChangeStream;
 
   Stream<StateChange> get stateChange {
     if (_stateChangeStream == null) {
@@ -68,5 +72,16 @@ class WiFiDirectBroadcastReceiver {
     }
 
     return _thisDeviceChangeStream;
+  }
+
+  Stream<DiscoveryStateChange> get discoveryChange {
+    if (_discoveryChangeStream == null) {
+      _discoveryChangeStream = _discoveryChangeChannel
+          .receiveBroadcastStream()
+          .map<DiscoveryStateChange>(
+              (src) => DiscoveryStateChange.fromBuffer(src));
+    }
+
+    return _discoveryChangeStream;
   }
 }

--- a/lib/gen/protos/protos.pb.dart
+++ b/lib/gen/protos/protos.pb.dart
@@ -572,3 +572,45 @@ class SocketMessage extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   void clearData() => clearField(3);
 }
+
+class DiscoveryStateChange extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i =
+      $pb.BuilderInfo('DiscoveryStateChange', createEmptyInstance: create)
+        ..aOB(1, 'isDiscovering', protoName: 'isDiscovering')
+        ..hasRequiredFields = false;
+
+  DiscoveryStateChange._() : super();
+  factory DiscoveryStateChange() => create();
+  factory DiscoveryStateChange.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DiscoveryStateChange.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  DiscoveryStateChange clone() =>
+      DiscoveryStateChange()..mergeFromMessage(this);
+  DiscoveryStateChange copyWith(void Function(DiscoveryStateChange) updates) =>
+      super.copyWith((message) => updates(message as DiscoveryStateChange));
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static DiscoveryStateChange create() => DiscoveryStateChange._();
+  DiscoveryStateChange createEmptyInstance() => create();
+  static $pb.PbList<DiscoveryStateChange> createRepeated() =>
+      $pb.PbList<DiscoveryStateChange>();
+  @$core.pragma('dart2js:noInline')
+  static DiscoveryStateChange getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DiscoveryStateChange>(create);
+  static DiscoveryStateChange _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get isDiscovering => $_getBF(0);
+  @$pb.TagNumber(1)
+  set isDiscovering($core.bool v) {
+    $_setBool(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasIsDiscovering() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearIsDiscovering() => clearField(1);
+}

--- a/lib/gen/protos/protos.pbjson.dart
+++ b/lib/gen/protos/protos.pbjson.dart
@@ -193,3 +193,10 @@ const SocketMessage$json = const {
     const {'1': 'data', '3': 3, '4': 1, '5': 12, '10': 'data'},
   ],
 };
+
+const DiscoveryStateChange$json = const {
+  '1': 'DiscoveryStateChange',
+  '2': const [
+    const {'1': 'isDiscovering', '3': 1, '4': 1, '5': 8, '10': 'isDiscovering'},
+  ],
+};

--- a/protos/protos.proto
+++ b/protos/protos.proto
@@ -82,3 +82,7 @@ message SocketMessage {
     int32 dataAvailable = 2; // The number of bytes which are still available
     bytes data = 3; // The data
 }
+
+message DiscoveryStateChange {
+    bool isDiscovering = 1;
+}


### PR DESCRIPTION
Hi Julian. Got another one if you are interested. This PR exposes the `WIFI_P2P_DISCOVERY_CHANGED_ACTION` events. I use these to do things like automatically call discover peers again if the discovery period times out if the user does not connect to a device. 

- Adds a new message type `DiscoveryStateChange` to protos
- Registers the `WIFI_P2P_DISCOVERY_CHANGED_ACTION` with the Broadcast receiver
- Adds a new `EventChannel` for the new event type


