### PR TITLE
Enable support for API level below 16(android version 4.1)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ android {
         main.proto.srcDirs += '../protos'
     }
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
I have discussed you on dev.to about this problem. Now I have modified it to support for below versions. 