### PR TITLE
Gradle task assembleDebug issue resolved & set min API level to 16

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,14 +30,14 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.google.protobuf'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         main.proto.srcDirs += '../protos'
     }
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
issue : #7  #5  #18 #bug

#7 Gradle build fails due to Kotlin gradle saying The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.10 and higher is now resolved. Accept the Pull the request please . 

#5 min sdk Version is set to API level 16.